### PR TITLE
Fix default action on Linux on pressing Enter

### DIFF
--- a/extension/dialog.html
+++ b/extension/dialog.html
@@ -59,7 +59,7 @@
     </div>
     <div class="row button-container">
         <button id="confirm" class="btn-ok" data-i18n="button_accept">Ok</button>
-        <button id="cancel" class="btn-cancel" data-i18n="button_cancel">Cancel</button>
+        <button type="button" id="cancel" class="btn-cancel" data-i18n="button_cancel">Cancel</button>
     </div>
 </fieldset>
 </form>


### PR DESCRIPTION
Since the buttons got reversed on Linux, the default action is Cancel.
Change its type to avoid this, this makes it possible to accept the
dialog by pressing Enter.