### PR TITLE
Ensure that "Open in browser as" is selected as needed

### DIFF
--- a/extension/dialog.js
+++ b/extension/dialog.js
@@ -262,6 +262,7 @@ function bindFormEvents() {
         $('mime-custom-completion').appendChild(options);
     };
     $('mime-type').onchange = function() {
+        document.querySelector('input[name="choice"][value="openas"]').checked = true;
         var isCustom = this.value === 'other';
         var mimeCustom = $('mime-custom');
         if (mimeCustom.hidden === isCustom) {


### PR DESCRIPTION
When changing the "Open in browser as" action (e.g. "Text", "Web page",
etc.), ensure that this option is selected rather than keeping the
previous option ("Open with Firefox" or "Save File").