### PR TITLE
Follow browser's light/dark theme style

### DIFF
--- a/extension/dialog.css
+++ b/extension/dialog.css
@@ -97,6 +97,7 @@ body {
 
 #url-protocol.https {
     color: green;
+    color: light-dark(green, lime);
     opacity: 1;
 }
 #url-protocol,
@@ -152,6 +153,6 @@ button, select {
     text-align: __MSG_@@bidi_end_edge__;
 }
 .options-link-wrapper a {
-    color: blue;
+    color: LinkText;
     font-size: smaller;
 }

--- a/extension/dialog.html
+++ b/extension/dialog.html
@@ -10,6 +10,7 @@
 <meta charset="utf-8">
 <title>Opening ...</title>
 <meta name="google" content="notranslate">
+<meta name="color-scheme" content="light dark">
 <link rel="stylesheet" type="text/css" href="dialog.css">
 </head>
 <body>

--- a/extension/options.html
+++ b/extension/options.html
@@ -26,6 +26,7 @@ h2 {
     font-size: 1.3em;
     margin: 0.6em 0;
     border-top: 1px dashed #888;
+    border-color: light-dark(#888, #777);
     padding-top: 0.2em;
 }
 .row {
@@ -38,6 +39,7 @@ h2 {
 .pref > .explanation {
     position: absolute;
     border: 1px solid #EEE;
+    border-color: light-dark(#EEE, #555);
     border-radius: 2px;
     box-shadow: 1px 1px 5px #000;
 
@@ -60,6 +62,7 @@ h2 {
 footer {
     margin-top: 1rem;
     border-top: 1px solid #CCC;
+    border-color: light-dark(#CCC, #666);
     padding: 1rem 0;
     
     font-size: 1rem;

--- a/extension/options.html
+++ b/extension/options.html
@@ -9,6 +9,7 @@
 <head>
 <meta charset="utf-8">
 <title>Open in Browser</title>
+<meta name="color-scheme" content="light dark">
 <style>
 body {
     font-family: 'Segoe UI', 'Lucida Grande', 'Ubuntu', sans-serif;
@@ -69,7 +70,7 @@ table {
 }
 .restored-to-default {
     text-decoration: line-through;
-    color: #999;
+    color: GrayText;
 }
 </style>
 </head>


### PR DESCRIPTION
Should sufficiently solve #63:

-   https://developer.mozilla.org/en-US/docs/Web/CSS/color-scheme
-   https://w3c.github.io/csswg-drafts/css-color-adjust/#color-scheme-prop

>   The ‘color-scheme’ property allows an element to indicate which color schemes it is designed to be rendered with. These values are negotiated with the user’s preferences, resulting in a used color scheme that affects things such as the default colors of form controls and scrollbars as well as the used values of the CSS system colors.
